### PR TITLE
Completed prep-css-display exercise.

### DIFF
--- a/prep-css-display/.npmrc
+++ b/prep-css-display/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/prep-css-display/index.html
+++ b/prep-css-display/index.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>CSS Display Properties</title>
+  <style>
+    div{
+      border: 4px solid blue;
+    }
+
+    span{
+      border: 4px solid green;
+      height: 100px;
+      width: 100px;
+    }
+
+    button{
+      border: 4px solid red;
+      height: 40px;
+      width: 200px;
+    }
+
+    ul{
+      border: 4px solid purple;
+    }
+
+    li{
+      border: 4px solid magenta;
+      display: inline;
+    }
+
+  </style>
+</head>
+<body>
+  <div>
+    I am a div and by default I am block, which means I take up all the space
+    I can horizontally.
+  </div>
+
+  <div>
+    I am a div but I have <span>span elements inside me</span>.
+    Span elements are <span>display inline by default</span>,
+    so they only take up as much space as they need.
+  </div>
+
+  <div>
+    <button>Hello!</button>
+    <button>Buttons are</button>
+    <button>Inline Block</button>
+    <button>By Default</button>
+  </div>
+
+  <ul>
+    <li>
+      Home
+    </li>
+    <li>
+      Products
+    </li>
+    <li>
+      About Us
+    </li>
+    <li>
+      Contact Us
+    </li>
+  </ul>
+
+</body>
+</html>


### PR DESCRIPTION
There seems to exist a space between the buttons which I don't see on the W3 tutorial. I double checked the instructions and it seems like I followed them correctly. I also tried to manually set the button as display: inline-block and it still had the same result. 

<img width="1440" alt="Screen Shot 2022-06-20 at 3 41 50 PM" src="https://user-images.githubusercontent.com/49361894/174685877-bcf3f627-d7a2-4976-9387-848339ef3cbe.png">
